### PR TITLE
Fixed issue where the Differ options were not passed to sub differs

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -88,6 +88,21 @@ type Differ struct {
 	Filter                 FilterFunc
 }
 
+func (d *Differ) Clone() Differ {
+	return Differ{
+		TagName:                d.TagName,
+		SliceOrdering:          d.SliceOrdering,
+		DisableStructValues:    d.DisableStructValues,
+		customValueDiffers:     d.customValueDiffers,
+		AllowTypeMismatch:      d.AllowTypeMismatch,
+		DiscardParent:          d.DiscardParent,
+		StructMapKeys:          d.StructMapKeys,
+		FlattenEmbeddedStructs: d.FlattenEmbeddedStructs,
+		ConvertCompatibleTypes: d.ConvertCompatibleTypes,
+		Filter:                 d.Filter,
+	}
+}
+
 // Changelog stores a list of changed items
 type Changelog []Change
 

--- a/diff_slice.go
+++ b/diff_slice.go
@@ -101,9 +101,7 @@ func (st *sliceTracker) has(s, v reflect.Value, d *Differ) bool {
 
 		x := s.Index(i)
 
-		var nd Differ
-		nd.Filter = d.Filter
-		nd.customValueDiffers = d.customValueDiffers
+		nd := d.Clone()
 
 		err := nd.diff([]string{}, x, v, nil)
 		if err != nil {

--- a/diff_struct.go
+++ b/diff_struct.go
@@ -69,9 +69,7 @@ func (d *Differ) diffStruct(path []string, a, b reflect.Value, parent interface{
 }
 
 func (d *Differ) structValues(t string, path []string, a reflect.Value) error {
-	var nd Differ
-	nd.Filter = d.Filter
-	nd.customValueDiffers = d.customValueDiffers
+	nd := d.Clone()
 
 	if t != CREATE && t != DELETE {
 		return ErrInvalidChangeType

--- a/diff_test.go
+++ b/diff_test.go
@@ -1146,6 +1146,84 @@ func TestHandleDifferentTypes(t *testing.T) {
 	}
 }
 
+func TestNestedSlicesAndStructsKeepingOptionsToProduceProperPathResult(t *testing.T) {
+
+	type Tag struct {
+		Value string `diff:"value"`
+	}
+
+	type Vitamin struct {
+		Name string `diff:"name"`
+		Tags []Tag  `diff:"tags"`
+	}
+
+	type Nutrient struct {
+		Name     string    `diff:"name"`
+		Vitamins []Vitamin `diff:"vitamins"`
+	}
+
+	type Fruit struct {
+		Name      string     `diff:"name"`
+		Nutrients []Nutrient `diff:"nutrients"`
+	}
+
+	a := Fruit{
+		Name: "Green Apple",
+		Nutrients: []Nutrient{
+			{
+				Name: "Vitamin A",
+				Vitamins: []Vitamin{
+					{
+						Name: "A1",
+						Tags: []Tag{
+							{
+								Value: "a1",
+							},
+						},
+					},
+					{
+						Name: "B1",
+						Tags: []Tag{
+							{
+								Value: "b1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	b := Fruit{
+		Name: "Green Apple",
+		Nutrients: []Nutrient{
+			{
+				Name: "Vitamin A",
+				Vitamins: []Vitamin{
+					{
+						Name: "A1",
+						Tags: []Tag{
+							{
+								Value: "a1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	d, err := diff.NewDiffer()
+	require.Nil(t, err)
+
+	cl, err := d.Diff(a, b)
+	require.Nil(t, err)
+
+	assert.Len(t, cl, 2)
+	assert.Equal(t, []string{"nutrients", "0", "vitamins", "1", "name"}, cl[0].Path)
+	assert.Equal(t, []string{"nutrients", "0", "vitamins", "1", "tags", "0", "value"}, cl[1].Path)
+}
+
 func copyAppend(src []string, elems ...string) []string {
 	dst := make([]string, len(src)+len(elems))
 	copy(dst, src)


### PR DESCRIPTION
The following fix ensure that we do not loose differ options when differs gets cloned during slice & struct diffing.